### PR TITLE
Fix h1 multiline overlap

### DIFF
--- a/jsdoc-template/static/styles/jsdoc.css
+++ b/jsdoc-template/static/styles/jsdoc.css
@@ -59,6 +59,7 @@ h1 {
   font-weight: 300;
   font-size: 48px;
   margin: 1em 0 .5em;
+  line-height: normal;
 }
 
 h1.page-title {


### PR DESCRIPTION
### Before
<img width="1440" alt="SS_ 2019-04-22 12 38 34" src="https://user-images.githubusercontent.com/9068885/56482040-fd8e2c00-64fc-11e9-9d74-d2143c891976.png">

### After
<img width="1425" alt="SS_ 2019-04-22 12 49 17" src="https://user-images.githubusercontent.com/9068885/56482055-1565b000-64fd-11e9-907c-c33b5f13b643.png">
