### PR TITLE
update styling of signature attributes

### DIFF
--- a/jsdoc-template/static/styles/jsdoc.css
+++ b/jsdoc-template/static/styles/jsdoc.css
@@ -152,7 +152,7 @@ section {
 
 .signature-attributes {
   font-size: 60%;
-  color: #eee;
+  color: #bbb;
   font-style: italic;
   font-weight: lighter;
 }


### PR DESCRIPTION
signature attributes are styled too light to easily see. This PR makes them a bit darker.