### PR TITLE
BREAKING CHANGE: Add support for app tokens in auth

### DIFF
--- a/bin/publish-docs.sh
+++ b/bin/publish-docs.sh
@@ -5,12 +5,13 @@ REPO_NAME=$1
 NAMESPACE=$2
 PAGES_DIR=./gh-pages
 DOCS_DIR=./out
-if [[ -z "${GH_TOKEN}" ]]; then # Check if GH_TOKEN is empty
-  TOKEN_GITHUB="${GITHUB_TOKEN}"
-else
-  TOKEN_GITHUB="${GH_TOKEN}"
+if [[ -n "${GITHUB_TOKEN}" ]]; then # If the GITHUB_TOKEN (which is an app token) is not empty we use an app token auth URL
+  REPO="https://x-access-token:${GITHUB_TOKEN}@github.com/contentful/${REPO_NAME}.git"
+else # Legacy variant
+  REPO="https://${GH_TOKEN}@github.com/contentful/${REPO_NAME}.git"
 fi
-REPO="https://${TOKEN_GITHUB}@github.com/contentful/${REPO_NAME}.git"
+
+
 VERSION=`cat package.json|json version`
 
 echo "Publishing docs"


### PR DESCRIPTION
Add support for app tokens additionally to Github user tokens.
`GH_TOKEN` is being used for user token authentication (legacy, will not be used internally once all repos are on secrets management)
`GITHUB_TOKEN` is being used for app token authentication 

While this shouldn't break the existing setups I still suggest making this a breaking change so that repos like `contentful-management` don't automtically update before they support vault secrets management.