### PR TITLE
feat: use vault for release secret []

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,15 +1,20 @@
 version: 2.1
+
+orbs:
+  vault: contentful/vault@1
+
 jobs:
   release:
     docker:
       - image: circleci/node:16
     steps:
       - checkout
+      - vault/get-secrets: # Loads vault secrets
+          template-preset: "semantic-release-ecosystem"
       - run: npm install
       - run: npm run semantic-release
 workflows:
-  version: 2
   build_and_test:
     jobs:
       - release:
-          context: dev-workflows-release
+          context: vault

--- a/.contentful/vault-secrets.yaml
+++ b/.contentful/vault-secrets.yaml
@@ -1,0 +1,8 @@
+version: 1
+services:
+  github-action:
+    policies:
+      - dependabot
+  circleci:
+    policies:
+      - semantic-release-ecosystem

--- a/.github/workflows/dependabot-approve-and-request-merge.yml
+++ b/.github/workflows/dependabot-approve-and-request-merge.yml
@@ -1,14 +1,15 @@
 name: "dependabot approve-and-request-merge"
 
-on:
-  pull_request_target
+on: pull_request_target
 
 jobs:
   worker:
+    permissions:
+      contents: write
+      id-token: write
     runs-on: ubuntu-latest
-
     if: github.actor == 'dependabot[bot]'
     steps:
-      - uses: contentful/dependabot-auto-merge@v1
+      - uses: contentful/github-auto-merge@v1
         with:
-          github_token: ${{ secrets.CF_ECOSYSTEM_BOT_GITHUB_TOKEN_AUTO_APPROVE }}
+          VAULT_URL: ${{ secrets.VAULT_URL }}


### PR DESCRIPTION
Uses the contentful's vault to get the npm for publishing instead of circleci's context