### PR TITLE
chore: node 18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,13 +2,12 @@ version: 2.1
 jobs:
   release:
     docker:
-      - image: circleci/node:16
+      - image: cimg/node:18.12.1
     steps:
       - checkout
       - run: npm install
       - run: npm run semantic-release
 workflows:
-  version: 2
   build_and_test:
     jobs:
       - release:


### PR DESCRIPTION
`semantic-release` updated to v20 and now requires node 18
