### PR TITLE
chore: use jq over json for compatibility []

### DIFF
--- a/bin/publish-docs.sh
+++ b/bin/publish-docs.sh
@@ -12,7 +12,7 @@ else # Legacy variant
 fi
 
 
-VERSION=`cat package.json|json version`
+VERSION=$(cat package.json | jq -r .version)
 
 echo "Publishing docs"
 


### PR DESCRIPTION
this is causing some downstream issues with environments not having `json`, `jq` is more widely available