### PR TITLE
chore: update ownership [EXT-00]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,4 @@
 * @contentful/team-tundra
+
+package.json
+package-lock.json

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -12,6 +12,7 @@ metadata:
   annotations:
     github.com/project-slug: contentful/contentful-sdk-jsdoc 
     contentful.com/service-tier: "unknown" #1, 2, 3, 4
+    contentful.com/ci-alert-slack: prd-extensibility-bots
 
   tags:
     - update-me


### PR DESCRIPTION
- updates CI alert chan
- unowns package*.json to allow dependabot+contentful automation to function properly