### PR TITLE
fix: replace unmaintained taffydb with jsdoc/salty [EXT-5968]

### DIFF
--- a/jsdoc-template/publish.js
+++ b/jsdoc-template/publish.js
@@ -6,7 +6,8 @@ var fs = require('jsdoc/fs');
 var helper = require('jsdoc/util/templateHelper');
 var logger = require('jsdoc/util/logger');
 var path = require('jsdoc/path');
-var taffy = require('taffydb').taffy;
+// https://github.com/jsdoc/jsdoc/tree/main/packages/jsdoc-salty#use-salty-in-a-jsdoc-template
+var taffy = require('@jsdoc/salty').taffy;
 var template = require('jsdoc/template');
 var util = require('util');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
-        "taffydb": "^2.7.3"
+        "@jsdoc/salty": "^0.2.8"
       },
       "devDependencies": {
         "@semantic-release/changelog": "^6.0.0",
@@ -288,10 +288,9 @@
       }
     },
     "node_modules/@jsdoc/salty": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@jsdoc/salty/-/salty-0.2.1.tgz",
-      "integrity": "sha512-JXwylDNSHa549N9uceDYu8D4GMXwSo3H8CCPYEQqxhhHpxD28+lRl2b3bS/caaPj5w1YD3SWtrficJNTnUjGpg==",
-      "dev": true,
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@jsdoc/salty/-/salty-0.2.8.tgz",
+      "integrity": "sha512-5e+SFVavj1ORKlKaKr2BmTOekmXbelU7dC0cDkQLqag7xfuTPuGMUFx7KWJuv4bYZrTsoL2Z18VVCOKYxzoHcg==",
       "dependencies": {
         "lodash": "^4.17.21"
       },
@@ -2951,8 +2950,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash-es": {
       "version": "4.17.21",
@@ -7642,11 +7640,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/taffydb": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.7.3.tgz",
-      "integrity": "sha512-GQ3gtYFSOAxSMN/apGtDKKkbJf+8izz5YfbGqIsUc7AMiQOapARZ76dhilRY2h39cynYxBFdafQo5HUL5vgkrg=="
-    },
     "node_modules/temp-dir": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-3.0.0.tgz",
@@ -8215,10 +8208,9 @@
       }
     },
     "@jsdoc/salty": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@jsdoc/salty/-/salty-0.2.1.tgz",
-      "integrity": "sha512-JXwylDNSHa549N9uceDYu8D4GMXwSo3H8CCPYEQqxhhHpxD28+lRl2b3bS/caaPj5w1YD3SWtrficJNTnUjGpg==",
-      "dev": true,
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@jsdoc/salty/-/salty-0.2.8.tgz",
+      "integrity": "sha512-5e+SFVavj1ORKlKaKr2BmTOekmXbelU7dC0cDkQLqag7xfuTPuGMUFx7KWJuv4bYZrTsoL2Z18VVCOKYxzoHcg==",
       "requires": {
         "lodash": "^4.17.21"
       }
@@ -10238,8 +10230,7 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash-es": {
       "version": "4.17.21",
@@ -13460,11 +13451,6 @@
           }
         }
       }
-    },
-    "taffydb": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.7.3.tgz",
-      "integrity": "sha512-GQ3gtYFSOAxSMN/apGtDKKkbJf+8izz5YfbGqIsUc7AMiQOapARZ76dhilRY2h39cynYxBFdafQo5HUL5vgkrg=="
     },
     "temp-dir": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -18,9 +18,6 @@
     "jsdoc*",
     "bin"
   ],
-  "dependencies": {
-    "taffydb": "^2.7.3"
-  },
   "devDependencies": {
     "@semantic-release/changelog": "^6.0.0",
     "cz-conventional-changelog": "^3.3.0",
@@ -55,5 +52,8 @@
       "@semantic-release/changelog",
       "@semantic-release/github"
     ]
+  },
+  "dependencies": {
+    "@jsdoc/salty": "^0.2.8"
   }
 }


### PR DESCRIPTION
replace taffydb

https://github.com/jsdoc/jsdoc/tree/main/packages/jsdoc-salty#use-salty-in-a-jsdoc-template