### PR TITLE
chore(ci): run ci on pull requests to enable github actions [DX-883]

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -5,6 +5,8 @@ permissions:
 on:
   push:
     branches: ['**']
+  pull_request:
+    branches: ['**']
 
 jobs:
 


### PR DESCRIPTION
## Summary
Add a github action trigger to `main.yml` to enable running the github actions by authorized package maintainers, on pull requests that originated from forked repos.

More context: https://contentful.atlassian.net/browse/DX-808

## PR Checklist

- [x] All commits follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Documentation is updated (if necessary)
- [x] PR doesn't contain any sensitive information
- [x] There are no breaking changes
